### PR TITLE
Add a SDK size section

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The Chat SDK requires system permissions, which allow for communication with Sen
 
 ### (Optional) Configure ProGuard to shrink code and resources
 
-When you build your APK with ```minifyEnabled true`, add the following line to the module's `ProGuard` rules file.
+When you build your APK with `minifyEnabled true`, add the following line to the module's `ProGuard` rules file.
 
 ```txt
 -dontwarn com.sendbird.android.shadow.**

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 1.  [Requirements](#requirements)
 1.  [Getting started](#getting-started)
 1.  [Sending your first message](#sending-your-first-message)
+1.  [Size of Chat SDK](#size-of-chat-sdk)
 1.  [Hiring](#we-are-hiring)
 
 <br />
@@ -121,7 +122,7 @@ The Chat SDK requires system permissions, which allow for communication with Sen
 
 ### (Optional) Configure ProGuard to shrink code and resources
 
-When you build your APK with `minifyEnabled true`, add the following line to the module's `ProGuard` rules file.
+When you build your APK with ```minifyEnabled true`, add the following line to the module's `ProGuard` rules file.
 
 ```txt
 -dontwarn com.sendbird.android.shadow.**
@@ -240,6 +241,13 @@ openChannel.sendUserMessage(MESSAGE) { message, e ->
 ```
 
 <br />
+
+## Size of Chat SDK
+
+The size of the Chat SDK is an important factor to consider when integrating it into your app. The size of the Chat SDK is as follows:
+
+- **SDK size**: 1.4 MB
+- **Minified SDK size**: 1.1 MB
 
 ## We are hiring
 


### PR DESCRIPTION
Added sections to README that provide the Minified SDK size and SDK size.

<img width="400" alt="image" src="https://github.com/sendbird/sendbird-chat-sdk-android/assets/157566674/72c21e6a-0122-4eb3-96e9-a8fa3f463306">

It will be updated during the distribution process, and the size analyzed by Emerge Tools.